### PR TITLE
Add proper comment tags

### DIFF
--- a/scoped-properties/language-html-swig.cson
+++ b/scoped-properties/language-html-swig.cson
@@ -2,3 +2,5 @@
   'editor':
     'increaseIndentPattern': '\\{%\\s*(if|for|block|autoescape|macro)'
     'decreaseIndentPattern': '(else|elseif|endif|empty|endfor|endblock|endautoescape|endmacro)\\s*%\\}'
+    'commentStart': '{# '
+    'commentEnd': ' #}'


### PR DESCRIPTION
Swig docs refer to the proper comment tags as `{# #}` not `<!-- -->`.